### PR TITLE
fix(test): remove obsolete obligation lane cap assertion

### DIFF
--- a/src/components/attempt/ObligationLanes.test.tsx
+++ b/src/components/attempt/ObligationLanes.test.tsx
@@ -86,8 +86,8 @@ describe('ObligationLanes', () => {
     expect(screen.getByText('GENERAL')).toBeInTheDocument();
     expect(screen.getByText('mini-ob-1-focused')).toBeInTheDocument();
     expect(screen.getByText('mini-ob-2-plain')).toBeInTheDocument();
+    // ob-3 is closed_proved so MiniTokenStream doesn't render for it
     expect(screen.queryByText('mini-ob-3-plain')).not.toBeInTheDocument();
-    expect(screen.getByText('+1 more obligation')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('Open step'));
     fireEvent.click(screen.getByText('mini-ob-1-focused'));


### PR DESCRIPTION
## Summary
- Remove `+1 more obligation` assertion since ObligationLanes no longer caps visible lanes

Closes #3

## Test plan
- [x] `npm run test:run` passes 83/83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to reflect obligation rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->